### PR TITLE
Py35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+__pycache__/
+
+private*

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ example.run_download(('your_gbif_user_name', 'your_password'))
 
 When adding a predicate for `COUNTRY` and a list of `TAXONKEY`s [3084923, 2498252, 3189866] as predicates, the resulting json will look like:
 
-```json
-{'created': 2016,
+```
+{'created: 2016,
  'creator': 'your_name',
  'notification_address': ['your_email'],
  'predicate': {'predicates': [{'key': 'COUNTRY',

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GBIF-downloads with Python 
+# GBIF-downloads with Python
 Create user downloads using the GBIF API http://www.gbif.org/developer/summary . Recognizing that the normal GBIF portal search and download services are not well suited for downloads based on a large number of species names, this module addresses the situation by allowing users to submit a file containing species keys. Additionally it allows users to add a map polygon to the search as well.   
 
 The script produces a JSON string consisting of predicates[1] which are fed into a service request.</br>
@@ -8,39 +8,62 @@ The script produces a JSON string consisting of predicates[1] which are fed into
 The script **does *not* return an object** since the request is handled entirely within the GBIF domain. Users should check the status of their downloads: http://www.gbif.org/user/download
 
 
-Two download patterns are directly supported: Searching by n taxonkeys, or searching by n taxonkeys and a polygon.
+## Usage GBIF downloader
 
-The variables below defined in the module can be modified to use different facets.
-
+In python, an object is created to start the json-building
 ```python
-geom = {'type': 'within', 'geometry': None}
-species = {'type': 'or', 'predicates': None}
-predicate_construct = {'type': 'equals', 'key': 'TAXON_KEY', 'value': None}
+example.GBIFDownload('your_name', 'your_email')
 ```
 
-## Usage pattern
+Three download patterns are directly supported:
+* Searching by n values for a specified variable, using the `add_iterative_predicate` function.
+* Searching relative (typically `within`) a Polygon, using the `add_geometry` function.
+* Adding a regular predicate (a value of a variable with a predicate type), using the `add_predicate` function
+
+The request can be executed by using the function `run_download`, which makes a request based on the given predicates:
+```python
+example.run_download(('your_gbif_user_name', 'your_password'))
+```
+
+When adding a predicate for `COUNTRY` and a list of `TAXONKEY`s [3084923, 2498252, 3189866] as predicates, the resulting json will look like:
+
+```json
+{'created': 2016,
+ 'creator': 'your_name',
+ 'notification_address': ['your_email'],
+ 'predicate': {'predicates': [{'key': 'COUNTRY',
+                               'type': 'equals',
+                               'value': 'BE'},
+                              {'predicates': [{'key': 'TAXON_KEY',
+                                               'type': 'equals',
+                                               'value': 3084923},
+                                              {'key': 'TAXON_KEY',
+                                               'type': 'equals',
+                                               'value': 2498252},
+                                              {'key': 'TAXON_KEY',
+                                               'type': 'equals',
+                                               'value': 3189866}],
+                               'type': 'or'}],
+               'type': 'and'},
+ 'send_notification': 'true'}
+```
+
+See `example_download.py` for the example code.
+
 The most typical usecase involves a number of species keys (sorry, but you have to get these first - use the excellent rgbif package from rOpenSci https://github.com/ropensci/rgbif or Scott Chamberlain's pygbif https://github.com/sckott/pygbif) and perhaps a map polygon.
 
-```python
-run_download("/home/user/Documents/species.csv", payload, 'username', 'user@mail.org', 
-              credentials=('username', 'passw0rd'), 
-              polygon='POLYGON((-14.0625 42.553080, 9.84375 38.272688, -7.03125 26.431228, -14.0625 42.553080))')
-#payload is already defined in the script but can be modified
-```
-You can omit the polygon and just query by taxon keys.
 
-Optionally you can override or modify the variables to get at other facets that the GBIF API surfaces. In this case a range of Basis-of-record:
+The download service can probably not handle more than a few hundred taxon-keys at the time, so limiting a request to < 100 keys to begin with would be prudent.
 
-```python
-import gbif_download as gd
+The same could be said for polygons - if a very complex shape (> 100 points) gets the download killed repeatedly, try simplifying the shape.
 
+## Usage GBIF Chunk downloader
 
-gd.predicate_construct['key'] = 'BASIS_OF_RECORD'
+To partly solve the issue of the limit on download restrictions, an extended version of the GBIF_downloader is available, which can process a list of values by making chunks and making individual requests.
 
-gd.run_download("/home/jan/Documents/lists/basis-of-record.csv", gd.payload, 'username', 'user@mail.org', 
-                credentials=('username', 'passw0rd'), 
-                polygon='POLYGON((-14.0625 42.553080, 9.84375 38.272688, -7.03125 26.431228, -14.0625 42.553080))')
-```
-##Caveats
-The download service can probably not handle more than a few hundred taxon keys at the time, so limiting a request to < 100 keys to begin with would be prudent.</br>
-The same could be said for polygons - if a very complex shape (> 100 points) gets the download killed repeatedly, try simplyfying the shape.
+The functionality provides two elements:
+ * split the original set of values (list) in chunks of a user-defined size
+ * send the requests for each chunk, taking into account the limit in
+   number of downloads by checking for each request if it is handled. The latter is done by checking if a new doi is available on the user/download page.
+
+See `example_chunk_download.py` for the example code.

--- a/example_chunk_download.py
+++ b/example_chunk_download.py
@@ -16,7 +16,7 @@ from gbif_download_chunks import GBIFChunkDownload
 
 # fill in name, email and cookie info for login
 example_chunk = GBIFChunkDownload('name', 'email',
-                                  cookies_dict=dict("key"="value"))
+                                  cookies_dict={"key": "value"})
 
 # require occurrences in Belgium
 example_chunk.add_predicate('COUNTRY', 'BE')

--- a/example_chunk_download.py
+++ b/example_chunk_download.py
@@ -1,0 +1,32 @@
+"""
+Name:   GBIF_download_chunks
+Author: Stijn Van Hoey, INBO, 2016-06-02
+
+In this example, username, email and credentials should be
+provided by the user in order to make the example work.
+
+To enable the chunk based version, a cookie-dict should be provided as well,
+by checking in the devtools of the browser for the cookie containing the key
+value information for the login.
+
+Chunk based GBIF download function
+"""
+
+from gbif_download_chunks import GBIFChunkDownload
+
+# fill in name, email and cookie info for login
+example_chunk = GBIFChunkDownload('name', 'email',
+                                  cookies_dict=dict("key"="value"))
+
+# require occurrences in Belgium
+example_chunk.add_predicate('COUNTRY', 'BE')
+
+#define the chunk size
+example_chunk.chunk_size = 5
+taxonkeys = ['3189866',  '2498252', '3084923', '2340977', '3170247', '3151811',
+             '3129663', '2441176', '2882443', '2437394', '5178057', '2439838',
+             '8104460', '2482499', '3025858', '3026024', '3026295', '3026294']
+
+# do the different requests (fill in user_name and password)
+example_chunk.run_iterative_download("TAXON_KEY", taxonkeys,
+                                     ('user_name', 'password'))

--- a/example_chunk_download.py
+++ b/example_chunk_download.py
@@ -21,7 +21,7 @@ example_chunk = GBIFChunkDownload('name', 'email',
 # require occurrences in Belgium
 example_chunk.add_predicate('COUNTRY', 'BE')
 
-#define the chunk size
+# define the chunk size
 example_chunk.chunk_size = 5
 taxonkeys = ['3189866',  '2498252', '3084923', '2340977', '3170247', '3151811',
              '3129663', '2441176', '2882443', '2437394', '5178057', '2439838',

--- a/example_download.py
+++ b/example_download.py
@@ -1,0 +1,27 @@
+"""
+Name:   GBIF_download_chunks
+Author: Stijn Van Hoey, INBO, 2016-06-02
+
+In this example, username, email and credentials should be
+provided by the user in order to make the example work.
+
+Default GBIF download function
+"""
+
+import pprint
+
+from gbif_download import GBIFDownload
+
+# fill in name and email
+example = GBIFDownload('name', 'email')
+
+# require occurrences in Belgium
+example.add_predicate('COUNTRY', 'BE')
+# require either of three taxonkeys
+example.add_iterative_predicate('TAXON_KEY', [3189866, 2498252, 3084923])
+pprint.pprint(example.payload)
+
+# do request (fill in user_name and password)
+example.run_download(('user_name', 'password'))
+
+

--- a/gbif_download_chunks.py
+++ b/gbif_download_chunks.py
@@ -1,0 +1,132 @@
+"""
+Name:   GBIF_download_chunks
+Author: Stijn Van Hoey, INBO, 2016-06-02
+Enables users to launch user_downloads against the GBIF API
+http://www.gbif.org/developer/occurrence#download
+Requires a user account on GBIF.org since credentials are needed.
+
+GBIF restricts the download in order to improve the spread of resources.
+Complex queries (e.g. >100 points in polygon, >50 taxonkeys) are killed and the
+maximal amount of downloads at the same time is set on 3
+(or 1 when requests peak).
+
+In order to handle these restrictions, this functionality provides
+two elements:
+ * split the original set of values (list) in chunks of a user-defined size
+ * send the requests for each chunk, taking into account the limit in
+   number of downloads
+"""
+
+from bs4 import BeautifulSoup
+import requests
+import time
+
+from gbif_download import GBIFDownload
+
+
+class GBIFChunkDownload(GBIFDownload):
+
+    def __init__(self, creator, email, cookies_dict,
+                 chunk_size=10, polygon=None):
+        """extension on the GBIFDownload to enable the chunkwise request of an
+        iterative predicate, as more complex queries are otherwise killed.
+        Moreover, the processing of the request is checked on the user download
+        page to verify the effective processing of the request (indirectly
+        taking into account the limits of 3 downloads at the same time)
+
+        :param creator: User name.
+        :param email: user email
+        :param cookies_dict: Dictionary with the combination of the cookie as
+        extracted from a browser after login into the GBIF webpage. This
+        is a rather hacky way of using the login and should be improved
+        :param chunk_size: number of values from an iterative that are
+        combined in a single request
+        :param polygon: Polygon of points to extract data from
+        """
+        super().__init__(creator, email, polygon)
+        self._chunk_size = chunk_size
+        self.cookies_dict = cookies_dict
+
+    @property
+    def chunk_size(self):
+        """get chunk_size"""
+        return self._chunk_size
+
+    @chunk_size.setter
+    def chunk_size(self, value):
+        """set chunk_size
+
+        :param value: size of the individual chunks used for the iterative
+        predicate
+        """
+        if value > 50:
+            print("Download service can probably not handle given chunk size.")
+        elif value < 0:
+            raise Exception("Negative chunk size not possible")
+        self._chunk_size = value
+
+    @staticmethod
+    def taxon_chunks(l, n):
+        """Yield successive n-sized chunks from a list.
+        """
+        for i in range(0, len(l), n):
+            yield l[i:i + n]
+
+    @staticmethod
+    def _get_current_dois(page):
+        """extract current doi values present on a page
+        """
+        doi_environments = page.find_all('dd')
+        dois = []
+        for el in doi_environments:
+            if el.find('a'):
+                if 'doi' in el.find('a').getText():
+                    dois.append(el.find('a').getText())
+        return dois
+
+    def scrape_doi_from_page(self):
+        """open the user page of gbif and scrape the current doi values present
+        on the first pager
+
+        :param cookies_dict: dictionary as derived from the cookies in the
+        browser when being logged in the http://www.gbif.org/user/download page
+        Rather 'hacky' way, but enables easy handling of the login procedure.
+        """
+        r = requests.get("http://www.gbif.org/user/download",
+                         cookies=self.cookies_dict)
+        soup = BeautifulSoup(r.content, "html.parser")
+        return self._get_current_dois(soup)
+
+    def run_iterative_download(self, key, values_list, credentials):
+        """
+        Splits the request of an iterative list of values in chunks to make
+        a set of requests.
+        It is assumed that only the predicate is only one level nested and
+        only one iterative element is processed
+
+        :param key: value for which the iterative is handled
+        :param values_list: Filename or list containing the taxon keys to be
+        searched.
+        :param credentials: Username and password tuple.
+        :return:
+        """
+        values = self._extract_values(values_list)
+
+        for subset_values in self.taxon_chunks(values, self.chunk_size):
+
+            # remove previous iterative predicates
+            predicate = []
+            for j, el in enumerate(self.predicates):
+                if "predicates" in el.keys():
+                    predicate.append(j)
+            if predicate:
+                for index in predicate:
+                    self.predicates.pop(index)
+
+            # add chunk as iterative predicate
+            self.add_iterative_predicate(key, subset_values)
+
+            ref_dois = self.scrape_doi_from_page()
+            while ref_dois == self.scrape_doi_from_page():
+                self.run_download(credentials)
+                time.sleep(60)


### PR DESCRIPTION
I adapted the code of the GBIF_download in order to make the creation of the json payload more generic, while keeping the main feature of the original GBIFdownload functionality:
- the setup of the payload is split in three different functions: `add_predicate`, `add_iterative_predicate` and `add_geometry`. `add_predicate` enables the user to add e;g. the predicate COUNTRY equals BE, which I could not easily add in the current master.
- The `run_download` functions takes the created payload dictionary as defined by these three functions and posts the request, instead of first creating the payload and then running it.
- The `GBIF_download` is setup as a class, making it more adaptable from the user-side.

Furthermore, an extension is created which can better handle the restrictions set on the number of downloads and the complexity of the request. `GBIFChunkDownload` is able to divide a list of values for a variable in chunks and provide them as separate requests. For each new requests, it checks the user/download page to see if the request is being processed (e.g. when limit of 3 downloads is reached). When not, it waits a minute and makes a new attempt. The way the doi-check is currently done is rather 'hacky' (using cookie information), but this can probably be further improved.

I understand that this request is providing a serious adaptation of the code, but I think the original requirement of doing a request for an iterative list is still fulfilled, while making it more general. 

Any feedback is welcome.
